### PR TITLE
Implement partial polymorphs

### DIFF
--- a/examples/core_api/endpoints/time_now_endpoint.rb
+++ b/examples/core_api/endpoints/time_now_endpoint.rb
@@ -14,6 +14,7 @@ module CoreAPI
       field :time_zones, type: [Objects::TimeZone]
       field :filters, [:string]
       field :my_polymorph, type: Objects::MonthPolymorph
+      field :my_partial_polymorph, type: Objects::MonthPolymorph, include: "number"
       scope "time"
 
       def call

--- a/examples/core_api/objects/month_long.rb
+++ b/examples/core_api/objects/month_long.rb
@@ -6,6 +6,10 @@ module CoreAPI
 
       description "Represents a month"
 
+      field :number, type: :integer do
+        backend { |t| t.strftime("%-m") }
+      end
+
       field :month_long, type: :string do
         backend { |t| t.strftime("%B") }
       end

--- a/examples/core_api/objects/month_short.rb
+++ b/examples/core_api/objects/month_short.rb
@@ -6,6 +6,10 @@ module CoreAPI
 
       description "Represents a month"
 
+      field :number, type: :integer do
+        backend { |t| t.strftime("%-m") }
+      end
+
       field :month_short, type: :string do
         backend { |t| t.strftime("%b") }
       end

--- a/lib/apia/open_api/objects/response.rb
+++ b/lib/apia/open_api/objects/response.rb
@@ -92,7 +92,17 @@ module Apia
             end
             properties[field_name] = { oneOf: refs }
           else
-            # TODO: https://github.com/krystal/apia-openapi/issues/13
+            # we assume the partially selected attributes must be present in all of the polymorph options
+            # and that each option returns the same data type for that attribute
+            object_schema = {}
+            Objects::Schema.new(
+              spec: @spec,
+              definition: field.type.klass.definition.options.values.first,
+              schema: object_schema,
+              endpoint: @endpoint,
+              path: [field]
+            ).add_to_spec
+            properties[field_name] = object_schema
           end
         end
 

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "active_support/inflector"
+require "active_support/core_ext"
 require_relative "helpers"
 require_relative "objects"
 

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -246,13 +246,22 @@
                           "$ref": "#/components/schemas/CoreAPI_Objects_MonthShort"
                         }
                       ]
+                    },
+                    "my_partial_polymorph": {
+                      "type": "object",
+                      "properties": {
+                        "number": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   },
                   "required": [
                     "time",
                     "time_zones",
                     "filters",
-                    "my_polymorph"
+                    "my_polymorph",
+                    "my_partial_polymorph"
                   ]
                 }
               }
@@ -321,13 +330,22 @@
                           "$ref": "#/components/schemas/CoreAPI_Objects_MonthShort"
                         }
                       ]
+                    },
+                    "my_partial_polymorph": {
+                      "type": "object",
+                      "properties": {
+                        "number": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   },
                   "required": [
                     "time",
                     "time_zones",
                     "filters",
-                    "my_polymorph"
+                    "my_polymorph",
+                    "my_partial_polymorph"
                   ]
                 }
               }
@@ -669,6 +687,9 @@
       "CoreAPI_Objects_MonthLong": {
         "type": "object",
         "properties": {
+          "number": {
+            "type": "integer"
+          },
           "month_long": {
             "type": "string"
           }
@@ -677,6 +698,9 @@
       "CoreAPI_Objects_MonthShort": {
         "type": "object",
         "properties": {
+          "number": {
+            "type": "integer"
+          },
           "month_short": {
             "type": "string"
           }


### PR DESCRIPTION
We need to handle when the endpoint has said a polymorph will be returned, but not all the fields will be included in the response. In that case we shouldn't just point to a $ref (as that implies all fields will be returned).

This is triggered by the Katapult API. So we do need it, specifically for `IPAddresses::InfoEndpoint`

For now I have assumed that if we are selecting specific attributes from the polymorph options, that those attributes appear in all the options and use the same data type. This is currently the case for Katapult, and just keeps it simpler.

closes: #13 