### PR TITLE
Handle nullable response fields

### DIFF
--- a/examples/core_api/controllers/time_controller.rb
+++ b/examples/core_api/controllers/time_controller.rb
@@ -19,7 +19,7 @@ module CoreAPI
         description "Format the given time"
         argument :time, type: ArgumentSets::TimeLookupArgumentSet, required: true
         argument :timezone, type: Objects::TimeZone
-        field :formatted_time, type: :string
+        field :formatted_time, type: :string, null: true
         action do
           time = request.arguments[:time]
           response.add_field :formatted_time, time.resolve.to_s

--- a/examples/core_api/endpoints/time_now_endpoint.rb
+++ b/examples/core_api/endpoints/time_now_endpoint.rb
@@ -12,9 +12,9 @@ module CoreAPI
       argument :filters, [:string]
       field :time, type: Objects::Time
       field :time_zones, type: [Objects::TimeZone]
-      field :filters, [:string]
+      field :filters, [:string], null: true
       field :my_polymorph, type: Objects::MonthPolymorph
-      field :my_partial_polymorph, type: Objects::MonthPolymorph, include: "number"
+      field :my_partial_polymorph, type: Objects::MonthPolymorph, include: "number", null: true
       scope "time"
 
       def call

--- a/lib/apia/open_api/objects/response.rb
+++ b/lib/apia/open_api/objects/response.rb
@@ -80,6 +80,7 @@ module Apia
               type: convert_type_to_open_api_data_type(field.type)
             }
           end
+          properties[field_name][:nullable] = true if field.null?
           properties
         end
 

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -47,7 +47,8 @@
                 "schema": {
                   "properties": {
                     "formatted_time": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -90,7 +91,8 @@
                 "schema": {
                   "properties": {
                     "formatted_time": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -235,7 +237,8 @@
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "nullable": true
                     },
                     "my_polymorph": {
                       "oneOf": [
@@ -253,7 +256,8 @@
                         "number": {
                           "type": "integer"
                         }
-                      }
+                      },
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -319,7 +323,8 @@
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "nullable": true
                     },
                     "my_polymorph": {
                       "oneOf": [
@@ -337,7 +342,8 @@
                         "number": {
                           "type": "integer"
                         }
-                      }
+                      },
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -407,7 +413,8 @@
                             }
                           }
                         }
-                      }
+                      },
+                      "nullable": true
                     },
                     "object_id": {
                       "type": "string"
@@ -467,7 +474,8 @@
                             }
                           }
                         }
-                      }
+                      },
+                      "nullable": true
                     },
                     "object_id": {
                       "type": "string"
@@ -520,7 +528,8 @@
                 "schema": {
                   "properties": {
                     "formatted_time": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -561,7 +570,8 @@
                 "schema": {
                   "properties": {
                     "formatted_time": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "required": [


### PR DESCRIPTION
In Apia we can add `null: true` to a field, like this:

```ruby
field :allocation, type: Objects::IPAddressAllocation, include: 'id,name', null: true
```

It means that in the response it will either be an `IPAddressAllocation` object or it might not be present at all.

In OpenAPI 3.0 we can represent this in the spec by using `nullable: true`.

closes: https://github.com/krystal/apia-openapi/issues/18