### PR TITLE
Add descriptions for LookupArgumentSets

### DIFF
--- a/examples/core_api/argument_sets/object_lookup.rb
+++ b/examples/core_api/argument_sets/object_lookup.rb
@@ -8,7 +8,9 @@ module CoreAPI
       description "Provides for objects to be looked up"
 
       argument :id, type: :string
-      argument :permalink, type: :string
+      argument :permalink, type: :string do
+        description "The permalink of the object to look up"
+      end
 
       potential_error "ObjectNotFound" do
         code :object_not_found

--- a/lib/apia/open_api/helpers.rb
+++ b/lib/apia/open_api/helpers.rb
@@ -38,6 +38,12 @@ module Apia
         definition.id.gsub(/\//, "_")
       end
 
+      def formatted_description(description)
+        return description if description.end_with?(".")
+
+        "#{description}."
+      end
+
     end
   end
 end

--- a/lib/apia/open_api/objects/schema.rb
+++ b/lib/apia/open_api/objects/schema.rb
@@ -70,6 +70,7 @@ module Apia
         def generate_child_schemas
           if @definition.type.argument_set?
             @children = @definition.type.klass.definition.arguments.values
+            @schema[:description] = "All '#{@definition.name}[]' params are mutually exclusive, only one can be provided."
           elsif @definition.type.object?
             @children = @definition.type.klass.definition.fields.values
           elsif @definition.type.enum?

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -22,14 +22,16 @@
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "time[string]",
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "timezone",
@@ -384,14 +386,16 @@
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "All 'object[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "object[permalink]",
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "The permalink of the object to look up. All 'object[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "scalar",
@@ -520,14 +524,16 @@
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "time[string]",
             "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "timezone",
@@ -618,6 +624,7 @@
         ]
       },
       "CoreAPI_ArgumentSets_TimeLookupArgumentSet": {
+        "description": "All 'time[]' params are mutually exclusive, only one can be provided.",
         "type": "object",
         "properties": {
           "unix": {
@@ -742,6 +749,7 @@
         }
       },
       "CoreAPI_ArgumentSets_ObjectLookup": {
+        "description": "All 'object[]' params are mutually exclusive, only one can be provided.",
         "type": "object",
         "properties": {
           "id": {


### PR DESCRIPTION
OpenAPI 3.0 does not support parameter dependencies and mutually exclusive parameters.

https://swagger.io/docs/specification/describing-parameters/#dependencies

This is a complex topic with a lot of debate:
https://github.com/OAI/OpenAPI-Specification/issues/256

We know that our LookupArgumentSets are mutually exclusive, so the best thing is to add a description explaining this, so that it will appear in documentation and tools like the swagger editor.

Apia already returns a 400 with a friendly error message.

closes: https://github.com/krystal/apia-openapi/issues/4

Swagger GET:
![Screenshot 2023-11-17 at 11 21 43](https://github.com/krystal/apia-openapi/assets/4964/53133a62-bf34-40f6-ace6-7fd3c3f502bb)


Swagger POST:
![Screenshot 2023-11-17 at 11 21 28](https://github.com/krystal/apia-openapi/assets/4964/aef4fd20-be2e-44ab-a670-52c869689cc0)
