### PR TITLE
Shorten ids for components

### DIFF
--- a/lib/apia/open_api/helpers.rb
+++ b/lib/apia/open_api/helpers.rb
@@ -49,9 +49,8 @@ module Apia
         end
       end
 
-      # forward slashes do not work in ids (e.g. schema ids)
       def generate_id_from_definition(definition)
-        definition.id.gsub(/\//, "")
+        definition.id.split("/").last
       end
 
       def formatted_description(description)

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -37,7 +37,7 @@
             "name": "timezone",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+              "$ref": "#/components/schemas/TimeZone"
             },
             "required": true
           }
@@ -62,13 +62,13 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsTimeLookupArgumentSetInvalidTimeResponse"
+            "$ref": "#/components/responses/InvalidTimeResponse"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "429": {
-            "$ref": "#/components/responses/CoreAPIErrorsRateLimitReachedResponse"
+            "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
       }
@@ -85,10 +85,10 @@
               "schema": {
                 "properties": {
                   "time": {
-                    "$ref": "#/components/schemas/CoreAPIArgumentSetsTimeLookupArgumentSet"
+                    "$ref": "#/components/schemas/TimeLookupArgumentSet"
                   },
                   "timezone": {
-                    "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                    "$ref": "#/components/schemas/TimeZone"
                   }
                 },
                 "required": [
@@ -119,13 +119,13 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsTimeLookupArgumentSetInvalidTimeResponse"
+            "$ref": "#/components/responses/InvalidTimeResponse"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "429": {
-            "$ref": "#/components/responses/CoreAPIErrorsRateLimitReachedResponse"
+            "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
       }
@@ -144,7 +144,7 @@
                   "times": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/CoreAPIArgumentSetsTimeLookupArgumentSet"
+                      "$ref": "#/components/schemas/TimeLookupArgumentSet"
                     }
                   }
                 },
@@ -184,13 +184,13 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsTimeLookupArgumentSetInvalidTimeResponse"
+            "$ref": "#/components/responses/InvalidTimeResponse"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "429": {
-            "$ref": "#/components/responses/CoreAPIErrorsRateLimitReachedResponse"
+            "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
       }
@@ -206,7 +206,7 @@
             "name": "timezone",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+              "$ref": "#/components/schemas/TimeZone"
             }
           },
           {
@@ -215,7 +215,7 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                "$ref": "#/components/schemas/TimeZone"
               }
             },
             "required": true
@@ -239,12 +239,12 @@
                 "schema": {
                   "properties": {
                     "time": {
-                      "$ref": "#/components/schemas/CoreAPIObjectsTime"
+                      "$ref": "#/components/schemas/Time"
                     },
                     "time_zones": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                        "$ref": "#/components/schemas/TimeZone"
                       }
                     },
                     "filters": {
@@ -257,10 +257,10 @@
                     "my_polymorph": {
                       "oneOf": [
                         {
-                          "$ref": "#/components/schemas/CoreAPIObjectsMonthLong"
+                          "$ref": "#/components/schemas/MonthLong"
                         },
                         {
-                          "$ref": "#/components/schemas/CoreAPIObjectsMonthShort"
+                          "$ref": "#/components/schemas/MonthShort"
                         }
                       ]
                     },
@@ -284,7 +284,7 @@
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "503": {
-            "$ref": "#/components/responses/CoreAPIAuthenticatorsTimeNowAuthenticatorWrongDayOfWeekResponse"
+            "$ref": "#/components/responses/WrongDayOfWeekResponse"
           }
         }
       },
@@ -299,12 +299,12 @@
               "schema": {
                 "properties": {
                   "timezone": {
-                    "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                    "$ref": "#/components/schemas/TimeZone"
                   },
                   "time_zones": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                      "$ref": "#/components/schemas/TimeZone"
                     }
                   },
                   "filters": {
@@ -329,12 +329,12 @@
                 "schema": {
                   "properties": {
                     "time": {
-                      "$ref": "#/components/schemas/CoreAPIObjectsTime"
+                      "$ref": "#/components/schemas/Time"
                     },
                     "time_zones": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                        "$ref": "#/components/schemas/TimeZone"
                       }
                     },
                     "filters": {
@@ -347,10 +347,10 @@
                     "my_polymorph": {
                       "oneOf": [
                         {
-                          "$ref": "#/components/schemas/CoreAPIObjectsMonthLong"
+                          "$ref": "#/components/schemas/MonthLong"
                         },
                         {
-                          "$ref": "#/components/schemas/CoreAPIObjectsMonthShort"
+                          "$ref": "#/components/schemas/MonthShort"
                         }
                       ]
                     },
@@ -374,7 +374,7 @@
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "503": {
-            "$ref": "#/components/responses/CoreAPIAuthenticatorsTimeNowAuthenticatorWrongDayOfWeekResponse"
+            "$ref": "#/components/responses/WrongDayOfWeekResponse"
           }
         }
       }
@@ -440,7 +440,7 @@
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "404": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsObjectLookupObjectNotFoundResponse"
+            "$ref": "#/components/responses/ObjectNotFoundResponse"
           }
         }
       },
@@ -455,7 +455,7 @@
               "schema": {
                 "properties": {
                   "object": {
-                    "$ref": "#/components/schemas/CoreAPIArgumentSetsObjectLookup"
+                    "$ref": "#/components/schemas/ObjectLookup"
                   },
                   "scalar": {
                     "type": "string"
@@ -498,7 +498,7 @@
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "404": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsObjectLookupObjectNotFoundResponse"
+            "$ref": "#/components/responses/ObjectNotFoundResponse"
           }
         }
       }
@@ -530,7 +530,7 @@
             "name": "timezone",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+              "$ref": "#/components/schemas/TimeZone"
             },
             "required": true
           }
@@ -555,13 +555,13 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsTimeLookupArgumentSetInvalidTimeResponse"
+            "$ref": "#/components/responses/InvalidTimeResponse"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "429": {
-            "$ref": "#/components/responses/CoreAPIErrorsRateLimitReachedResponse"
+            "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
       },
@@ -576,10 +576,10 @@
               "schema": {
                 "properties": {
                   "time": {
-                    "$ref": "#/components/schemas/CoreAPIArgumentSetsTimeLookupArgumentSet"
+                    "$ref": "#/components/schemas/TimeLookupArgumentSet"
                   },
                   "timezone": {
-                    "$ref": "#/components/schemas/CoreAPIObjectsTimeZone"
+                    "$ref": "#/components/schemas/TimeZone"
                   }
                 },
                 "required": [
@@ -610,13 +610,13 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/CoreAPIArgumentSetsTimeLookupArgumentSetInvalidTimeResponse"
+            "$ref": "#/components/responses/InvalidTimeResponse"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
           },
           "429": {
-            "$ref": "#/components/responses/CoreAPIErrorsRateLimitReachedResponse"
+            "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
       }
@@ -624,7 +624,7 @@
   },
   "components": {
     "schemas": {
-      "CoreAPIObjectsTimeZone": {
+      "TimeZone": {
         "type": "string",
         "enum": [
           "Europe/London",
@@ -632,7 +632,7 @@
           "Asia/Singapore"
         ]
       },
-      "CoreAPIAuthenticatorsMainAuthenticatorInvalidToken": {
+      "InvalidToken": {
         "type": "object",
         "properties": {
           "given_token": {
@@ -640,7 +640,7 @@
           }
         }
       },
-      "CoreAPIAuthenticatorsMainAuthenticatorInvalidTokenResponse": {
+      "InvalidTokenResponse": {
         "type": "object",
         "description": "The token provided is invalid. In this example, you should provide 'example'.",
         "properties": {
@@ -654,11 +654,11 @@
             "type": "string"
           },
           "detail": {
-            "$ref": "#/components/schemas/CoreAPIAuthenticatorsMainAuthenticatorInvalidToken"
+            "$ref": "#/components/schemas/InvalidToken"
           }
         }
       },
-      "CoreAPIAuthenticatorsMainAuthenticatorUnauthorizedNetworkForAPIToken": {
+      "UnauthorizedNetworkForAPIToken": {
         "type": "object",
         "properties": {
           "ip_address": {
@@ -666,7 +666,7 @@
           }
         }
       },
-      "CoreAPIAuthenticatorsMainAuthenticatorUnauthorizedNetworkForAPITokenResponse": {
+      "UnauthorizedNetworkForAPITokenResponse": {
         "type": "object",
         "description": "Network is not allowed to access the API with this API token",
         "properties": {
@@ -680,11 +680,11 @@
             "type": "string"
           },
           "detail": {
-            "$ref": "#/components/schemas/CoreAPIAuthenticatorsMainAuthenticatorUnauthorizedNetworkForAPIToken"
+            "$ref": "#/components/schemas/UnauthorizedNetworkForAPIToken"
           }
         }
       },
-      "CoreAPIErrorsRateLimitReached": {
+      "RateLimitReached": {
         "type": "object",
         "properties": {
           "total_permitted": {
@@ -692,7 +692,7 @@
           }
         }
       },
-      "CoreAPIArgumentSetsTimeLookupArgumentSet": {
+      "TimeLookupArgumentSet": {
         "description": "All 'time[]' params are mutually exclusive, only one can be provided.",
         "type": "object",
         "properties": {
@@ -740,23 +740,23 @@
           }
         }
       },
-      "CoreAPIObjectsTime": {
+      "Time": {
         "type": "object",
         "properties": {
           "unix": {
             "type": "integer"
           },
           "day_of_week": {
-            "$ref": "#/components/schemas/CoreAPIObjectsDay"
+            "$ref": "#/components/schemas/Day"
           },
           "full": {
             "type": "string"
           },
           "year": {
-            "$ref": "#/components/schemas/CoreAPIObjectsYear"
+            "$ref": "#/components/schemas/Year"
           },
           "month": {
-            "$ref": "#/components/schemas/CoreAPIObjectsMonthPolymorph"
+            "$ref": "#/components/schemas/MonthPolymorph"
           },
           "as_array": {
             "type": "array",
@@ -767,7 +767,7 @@
           "as_array_of_objects": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CoreAPIObjectsYear"
+              "$ref": "#/components/schemas/Year"
             }
           },
           "as_decimal": {
@@ -778,7 +778,7 @@
           }
         }
       },
-      "CoreAPIObjectsDay": {
+      "Day": {
         "type": "string",
         "enum": [
           "Sunday",
@@ -790,7 +790,7 @@
           "Saturday"
         ]
       },
-      "CoreAPIObjectsYear": {
+      "Year": {
         "type": "object",
         "properties": {
           "as_integer": {
@@ -808,27 +808,27 @@
           "as_array_of_enums": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CoreAPIObjectsDay"
+              "$ref": "#/components/schemas/Day"
             }
           }
         }
       },
-      "CoreAPIObjectsMonthPolymorph": {
+      "MonthPolymorph": {
         "type": "object",
         "properties": {
           "month": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/CoreAPIObjectsMonthLong"
+                "$ref": "#/components/schemas/MonthLong"
               },
               {
-                "$ref": "#/components/schemas/CoreAPIObjectsMonthShort"
+                "$ref": "#/components/schemas/MonthShort"
               }
             ]
           }
         }
       },
-      "CoreAPIObjectsMonthLong": {
+      "MonthLong": {
         "type": "object",
         "properties": {
           "number": {
@@ -839,7 +839,7 @@
           }
         }
       },
-      "CoreAPIObjectsMonthShort": {
+      "MonthShort": {
         "type": "object",
         "properties": {
           "number": {
@@ -873,7 +873,7 @@
             "type": "integer"
           },
           "day_of_week": {
-            "$ref": "#/components/schemas/CoreAPIObjectsDay"
+            "$ref": "#/components/schemas/Day"
           },
           "year": {
             "$ref": "#/components/schemas/GetTestObject200ResponseTimeYear"
@@ -888,7 +888,7 @@
           }
         }
       },
-      "CoreAPIEndpointsTestEndpointInvalidTestResponse": {
+      "InvalidTestResponse": {
         "type": "object",
         "properties": {
           "code": {
@@ -905,7 +905,7 @@
           }
         }
       },
-      "CoreAPIEndpointsTestEndpointAnotherInvalidTestResponse": {
+      "AnotherInvalidTestResponse": {
         "type": "object",
         "properties": {
           "code": {
@@ -922,7 +922,7 @@
           }
         }
       },
-      "CoreAPIArgumentSetsObjectLookup": {
+      "ObjectLookup": {
         "description": "All 'object[]' params are mutually exclusive, only one can be provided.",
         "type": "object",
         "properties": {
@@ -941,7 +941,7 @@
             "type": "integer"
           },
           "day_of_week": {
-            "$ref": "#/components/schemas/CoreAPIObjectsDay"
+            "$ref": "#/components/schemas/Day"
           },
           "year": {
             "$ref": "#/components/schemas/PostTestObject200ResponseTimeYear"
@@ -958,7 +958,7 @@
       }
     },
     "responses": {
-      "CoreAPIArgumentSetsTimeLookupArgumentSetInvalidTimeResponse": {
+      "InvalidTimeResponse": {
         "description": "400 error response",
         "content": {
           "application/json": {
@@ -988,17 +988,17 @@
             "schema": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/CoreAPIAuthenticatorsMainAuthenticatorInvalidTokenResponse"
+                  "$ref": "#/components/schemas/InvalidTokenResponse"
                 },
                 {
-                  "$ref": "#/components/schemas/CoreAPIAuthenticatorsMainAuthenticatorUnauthorizedNetworkForAPITokenResponse"
+                  "$ref": "#/components/schemas/UnauthorizedNetworkForAPITokenResponse"
                 }
               ]
             }
           }
         }
       },
-      "CoreAPIErrorsRateLimitReachedResponse": {
+      "RateLimitReachedResponse": {
         "description": "You have reached the rate limit for this type of request",
         "content": {
           "application/json": {
@@ -1014,14 +1014,14 @@
                   "type": "string"
                 },
                 "detail": {
-                  "$ref": "#/components/schemas/CoreAPIErrorsRateLimitReached"
+                  "$ref": "#/components/schemas/RateLimitReached"
                 }
               }
             }
           }
         }
       },
-      "CoreAPIAuthenticatorsTimeNowAuthenticatorWrongDayOfWeekResponse": {
+      "WrongDayOfWeekResponse": {
         "description": "You called this API on the wrong day of the week, try again tomorrow",
         "content": {
           "application/json": {
@@ -1051,17 +1051,17 @@
             "schema": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/CoreAPIEndpointsTestEndpointInvalidTestResponse"
+                  "$ref": "#/components/schemas/InvalidTestResponse"
                 },
                 {
-                  "$ref": "#/components/schemas/CoreAPIEndpointsTestEndpointAnotherInvalidTestResponse"
+                  "$ref": "#/components/schemas/AnotherInvalidTestResponse"
                 }
               ]
             }
           }
         }
       },
-      "CoreAPIArgumentSetsObjectLookupObjectNotFoundResponse": {
+      "ObjectNotFoundResponse": {
         "description": "No object was found matching any of the criteria provided in the arguments",
         "content": {
           "application/json": {
@@ -1091,10 +1091,10 @@
             "schema": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/CoreAPIEndpointsTestEndpointInvalidTestResponse"
+                  "$ref": "#/components/schemas/InvalidTestResponse"
                 },
                 {
-                  "$ref": "#/components/schemas/CoreAPIEndpointsTestEndpointAnotherInvalidTestResponse"
+                  "$ref": "#/components/schemas/AnotherInvalidTestResponse"
                 }
               ]
             }
@@ -1103,7 +1103,7 @@
       }
     },
     "securitySchemes": {
-      "CoreAPIAuthenticatorsMainAuthenticator": {
+      "MainAuthenticator": {
         "scheme": "bearer",
         "type": "http"
       }
@@ -1111,7 +1111,7 @@
   },
   "security": [
     {
-      "CoreAPIAuthenticatorsMainAuthenticator": [
+      "MainAuthenticator": [
 
       ]
     }


### PR DESCRIPTION
This makes all the classes and types far less "wordy" in the generated code.

This was especially a problem in the generated go client code, which was producing exceptionally long names for enum consts that cannot clash across the entire api.

This change does introduce a risk that two unrelated things could end up with the same id. In the Katapult API this doesn't appear to be the case.

If an API introduced this, we could either:
1. rename the conflicting thing to something unique
2. introduce some kind of "collision detection", where we check the full id against the shortened id. and don't re-use the id if it already points to something else.

closes: https://github.com/krystal/apia-openapi/issues/26