### PR TITLE
Improve error response names

### DIFF
--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -434,7 +434,7 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/GetTestObject400Response"
+            "$ref": "#/components/responses/InvalidTestAnotherInvalidTest400Response"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
@@ -492,7 +492,7 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/PostTestObject400Response"
+            "$ref": "#/components/responses/InvalidTestAnotherInvalidTest400Response"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
@@ -683,6 +683,16 @@
             "$ref": "#/components/schemas/UnauthorizedNetworkForAPIToken"
           }
         }
+      },
+      "OneOfAPIAuthenticator403Response": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InvalidTokenResponse"
+          },
+          {
+            "$ref": "#/components/schemas/UnauthorizedNetworkForAPITokenResponse"
+          }
+        ]
       },
       "RateLimitReached": {
         "type": "object",
@@ -922,6 +932,16 @@
           }
         }
       },
+      "OneOfInvalidTestAnotherInvalidTest400Response": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InvalidTestResponse"
+          },
+          {
+            "$ref": "#/components/schemas/AnotherInvalidTestResponse"
+          }
+        ]
+      },
       "ObjectLookup": {
         "description": "All 'object[]' params are mutually exclusive, only one can be provided.",
         "type": "object",
@@ -986,14 +1006,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/InvalidTokenResponse"
-                },
-                {
-                  "$ref": "#/components/schemas/UnauthorizedNetworkForAPITokenResponse"
-                }
-              ]
+              "$ref": "#/components/schemas/OneOfAPIAuthenticator403Response"
             }
           }
         }
@@ -1044,19 +1057,12 @@
           }
         }
       },
-      "GetTestObject400Response": {
+      "InvalidTestAnotherInvalidTest400Response": {
         "description": "400 error response",
         "content": {
           "application/json": {
             "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/InvalidTestResponse"
-                },
-                {
-                  "$ref": "#/components/schemas/AnotherInvalidTestResponse"
-                }
-              ]
+              "$ref": "#/components/schemas/OneOfInvalidTestAnotherInvalidTest400Response"
             }
           }
         }
@@ -1080,23 +1086,6 @@
                   "type": "object"
                 }
               }
-            }
-          }
-        }
-      },
-      "PostTestObject400Response": {
-        "description": "400 error response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/InvalidTestResponse"
-                },
-                {
-                  "$ref": "#/components/schemas/AnotherInvalidTestResponse"
-                }
-              ]
             }
           }
         }


### PR DESCRIPTION
Currently we declare the same 403 response many times over for many endpoints. Just with a unique name for the endpoint. Same for other http status codes.

We did that because for other parts of the code generator, generating unique component refs forced the generator not to be "smart" and re-use things across different endpoints.

However, this is not the case with the error responses.

So DeleteVirtualMachine403Response is actually being used for ~43 different api calls. Not obviously all related to deleting a virtual machine.

Now we name the error response after the errors it returns (excluding the api authenticator ones applied to all responses).

In addition, we don't declare the `oneOf` inside the response, that has been moved to another named schema definition and then referenced from the response. This forces the generator to use the named schema and not try to be "clever".

closes: https://github.com/krystal/apia-openapi/issues/28