### PR TITLE
Improve accuracy of data types for numbers

### DIFF
--- a/lib/apia/open_api/helpers.rb
+++ b/lib/apia/open_api/helpers.rb
@@ -38,6 +38,14 @@ module Apia
         end
       end
 
+      def generate_scalar_schema(type)
+        schema = {
+          type: convert_type_to_open_api_data_type(type)
+        }
+        schema[:format] = "float" if type.klass == Apia::Scalars::Decimal
+        schema
+      end
+
       def generate_schema_ref(definition, id: nil, **schema_opts)
         id ||= generate_id_from_definition(definition.type.klass.definition)
         success = add_to_components_schemas(definition, id, **schema_opts)

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -39,7 +39,7 @@ module Apia
             if @argument.type.enum? || @argument.type.object?
               items = generate_schema_ref(@argument)
             else
-              items = { type: convert_type_to_open_api_data_type(@argument.type) }
+              items = generate_scalar_schema(@argument.type)
             end
 
             param = {
@@ -64,9 +64,7 @@ module Apia
             param = {
               name: @argument.name.to_s,
               in: "query",
-              schema: {
-                type: convert_type_to_open_api_data_type(@argument.type)
-              }
+              schema: generate_scalar_schema(@argument.type)
             }
             param[:required] = true if @argument.required?
             add_to_parameters(param)
@@ -84,9 +82,7 @@ module Apia
             param = {
               name: "#{@argument.name}[#{child_arg.name}]",
               in: "query",
-              schema: {
-                type: convert_type_to_open_api_data_type(child_arg.type)
-              }
+              schema: generate_scalar_schema(child_arg.type)
             }
             description = []
             description << formatted_description(child_arg.description) if child_arg.description.present?

--- a/lib/apia/open_api/objects/request_body.rb
+++ b/lib/apia/open_api/objects/request_body.rb
@@ -38,7 +38,7 @@ module Apia
               if arg.type.argument_set? || arg.type.enum?
                 items = generate_schema_ref(arg)
               else
-                items = { type: convert_type_to_open_api_data_type(arg.type) }
+                items = generate_scalar_schema(arg.type)
               end
 
               @properties[arg.name.to_s] = {
@@ -47,10 +47,8 @@ module Apia
               }
             elsif arg.type.argument_set? || arg.type.enum?
               @properties[arg.name.to_s] = generate_schema_ref(arg)
-            else # scalar
-              @properties[arg.name.to_s] = {
-                type: convert_type_to_open_api_data_type(arg.type)
-              }
+            else
+              @properties[arg.name.to_s] = generate_scalar_schema(arg.type)
             end
           end
 

--- a/lib/apia/open_api/objects/response.rb
+++ b/lib/apia/open_api/objects/response.rb
@@ -81,10 +81,8 @@ module Apia
             build_properties_for_array(field_name, field, properties)
           elsif field.type.object? || field.type.enum?
             build_properties_for_object_or_enum(field_name, field, properties)
-          else # scalar
-            properties[field_name] = {
-              type: convert_type_to_open_api_data_type(field.type)
-            }
+          else
+            properties[field_name] = generate_scalar_schema(field.type)
           end
           properties[field_name][:nullable] = true if field.null?
           properties

--- a/lib/apia/open_api/objects/schema.rb
+++ b/lib/apia/open_api/objects/schema.rb
@@ -127,9 +127,7 @@ module Apia
           else # scalar
             schema[:type] = "object"
             schema[:properties] ||= {}
-            schema[:properties][child.name.to_s] = {
-              type: convert_type_to_open_api_data_type(child.type)
-            }
+            schema[:properties][child.name.to_s] = generate_scalar_schema(child.type)
           end
 
           if child.try(:required?)

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -781,7 +781,8 @@
             }
           },
           "as_decimal": {
-            "type": "number"
+            "type": "number",
+            "format": "float"
           },
           "as_base64": {
             "type": "string"


### PR DESCRIPTION
Now when we know we will return a float, we declare `"format": "float"` which is an optional hint.

https://swagger.io/docs/specification/data-models/data-types/#numbers

closes: https://github.com/krystal/apia-openapi/issues/5