### PR TITLE
Improve data-types, handle dates

### DIFF
--- a/examples/core_api/objects/time.rb
+++ b/examples/core_api/objects/time.rb
@@ -46,6 +46,10 @@ module CoreAPI
         backend { |t| Base64.encode64(t.to_s) }
       end
 
+      field :as_date, type: :date do
+        backend { |t| t.strftime("%Y-%m-%d") }
+      end
+
     end
   end
 end

--- a/lib/apia/open_api/helpers.rb
+++ b/lib/apia/open_api/helpers.rb
@@ -27,14 +27,17 @@ module Apia
       end
 
       def convert_type_to_open_api_data_type(type)
-        if type.klass == Apia::Scalars::UnixTime
-          "integer"
-        elsif type.klass == Apia::Scalars::Decimal
-          "number"
-        elsif type.klass == Apia::Scalars::Base64
+        case type.klass.to_s
+        when "Apia::Scalars::String", "Apia::Scalars::Base64", "Apia::Scalars::Date"
           "string"
+        when "Apia::Scalars::Integer", "Apia::Scalars::UnixTime"
+          "integer"
+        when "Apia::Scalars::Decimal"
+          "number"
+        when "Apia::Scalars::Boolean"
+          "boolean"
         else
-          type.klass.definition.name.downcase
+          raise "Unknown Apia type #{type.klass} mapping to OpenAPI type"
         end
       end
 
@@ -43,6 +46,7 @@ module Apia
           type: convert_type_to_open_api_data_type(type)
         }
         schema[:format] = "float" if type.klass == Apia::Scalars::Decimal
+        schema[:format] = "date" if type.klass == Apia::Scalars::Date
         schema
       end
 

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -786,6 +786,10 @@
           },
           "as_base64": {
             "type": "string"
+          },
+          "as_date": {
+            "type": "string",
+            "format": "date"
           }
         }
       },


### PR DESCRIPTION
Now we explicitly map all Apia data types to the OpenAPI equivalent.

https://swagger.io/docs/specification/data-models/data-types/

Adds support for the date type

closes: https://github.com/krystal/apia-openapi/issues/14