### PR TITLE
Add a default description for the entire API

### DIFF
--- a/examples/core_api/base.rb
+++ b/examples/core_api/base.rb
@@ -9,6 +9,8 @@ module CoreAPI
 
     authenticator Authenticators::MainAuthenticator
 
+    name "Example API"
+
     scopes do
       add "time", "Allows time telling functions"
     end

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -46,11 +46,12 @@ module Apia
       end
 
       def add_info
+        title = @api.definition.name || @api.definition.id
         @spec[:info] = {
           version: "1.0.0",
-          title: @api.definition.name || @api.definition.id
+          title: title
         }
-        @spec[:info][:description] = @api.definition.description unless @api.definition.description.nil?
+        @spec[:info][:description] = @api.definition.description || "Welcome to the documentation for the #{title}"
       end
 
       def add_servers

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -2,7 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
-    "title": "CoreAPI/Base"
+    "title": "Example API",
+    "description": "Welcome to the documentation for the Example API"
   },
   "servers": [
     {


### PR DESCRIPTION
In the generated Ruby client, the description is used on the Readme.

If we don't supply one then it just says:
No description provided (generated by Openapi Generator https://github.com/openapitools/openapi-generator)

Which looks a bit naf

closes: https://github.com/krystal/apia-openapi/issues/33