### PR TITLE
feat: limit the generated names of the $refs

### DIFF
--- a/examples/core_api/base.rb
+++ b/examples/core_api/base.rb
@@ -18,7 +18,8 @@ module CoreAPI
     routes do
       schema
 
-      get "time_formatting/format", controller: Controllers::TimeController, endpoint: :format
+      get "time_formatting/incredibly/super/duper/long/format", controller: Controllers::TimeController,
+                                                                endpoint: :format
       post "example/format", controller: Controllers::TimeController, endpoint: :format
       post "example/format_multiple", controller: Controllers::TimeController, endpoint: :format_multiple
 
@@ -35,7 +36,7 @@ module CoreAPI
           name "Formatting"
           controller Controllers::TimeController
 
-          get "time/formatting/format", endpoint: :format
+          get "time/formatting/incredibly/super/duper/long/format", endpoint: :format
           post "time/formatting/format", endpoint: :format
         end
       end

--- a/examples/core_api/endpoints/test_endpoint.rb
+++ b/examples/core_api/endpoints/test_endpoint.rb
@@ -24,13 +24,30 @@ module CoreAPI
 
       scope "time"
 
-      potential_error "InvalidTest" do
+      # The number of potential errors here is intentionally high to test that
+      # we can successfully generate a truncated $ref ID for the OpenAPI spec.
+      potential_error "SomethingVeryLongProblemBoom" do
         code :invalid_test
+        http_status 400
+      end
+
+      potential_error "SoManyProblemsSoLittleTime" do
+        code :so_many_problems
         http_status 400
       end
 
       potential_error "AnotherInvalidTest" do
         code :another_invalid_test
+        http_status 400
+      end
+
+      potential_error "SomethingWrong" do
+        code :something_wrong
+        http_status 400
+      end
+
+      potential_error "ReallyWrong" do
+        code :really_wrong
         http_status 400
       end
 

--- a/lib/apia/open_api/objects/schema.rb
+++ b/lib/apia/open_api/objects/schema.rb
@@ -144,9 +144,14 @@ module Apia
             schema[:properties][child.name.to_s] = generate_schema_ref(child)
           else
             child_path = @path.nil? ? nil : @path + [child]
+
+            # Nested partial fields in the response have the potential to generate
+            # very long IDs, so we truncate them to avoid hitting the 100 character
+            # filename limit imposed by the rubygems gem builder.
+            truncated_id = @id.match(/^(.*?)\d*?(Response|Part).*$/)[1]
             schema[:properties][child.name.to_s] = generate_schema_ref(
               child,
-              id: "#{@id}_#{child.name}".camelize,
+              id: "#{truncated_id}Part_#{child.name}".camelize,
               endpoint: @endpoint,
               path: child_path
             )

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -11,9 +11,9 @@
     }
   ],
   "paths": {
-    "/time_formatting/format": {
+    "/time_formatting/incredibly/super/duper/long/format": {
       "get": {
-        "operationId": "get:time_formatting_format",
+        "operationId": "get:time_formatting_incredibly_super_duper_long_format",
         "tags": [
           "Core"
         ],
@@ -469,7 +469,7 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/InvalidTestAnotherInvalidTest400Response"
+            "$ref": "#/components/responses/AnotherInvalidTestSomethingVeryLongProblemBoomSomethingWrong400Error"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
@@ -532,7 +532,7 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/InvalidTestAnotherInvalidTest400Response"
+            "$ref": "#/components/responses/AnotherInvalidTestSomethingVeryLongProblemBoomSomethingWrong400Error"
           },
           "403": {
             "$ref": "#/components/responses/APIAuthenticator403Response"
@@ -543,9 +543,9 @@
         }
       }
     },
-    "/time/formatting/format": {
+    "/time/formatting/incredibly/super/duper/long/format": {
       "get": {
-        "operationId": "get:time/formatting/format",
+        "operationId": "get:t_f_i_s_d_l_f",
         "tags": [
           "Core"
         ],
@@ -605,7 +605,9 @@
             "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
-      },
+      }
+    },
+    "/time/formatting/format": {
       "post": {
         "operationId": "post:time_formatting_format",
         "tags": [
@@ -768,17 +770,17 @@
             "type": "integer"
           },
           "year": {
-            "$ref": "#/components/schemas/PostExampleFormatMultiple200ResponseTimesYear"
+            "$ref": "#/components/schemas/PostExampleFormatMultiplePartYear"
           },
           "as_array_of_objects": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PostExampleFormatMultiple200ResponseTimesAsArrayOfObjects"
+              "$ref": "#/components/schemas/PostExampleFormatMultiplePartAsArrayOfObjects"
             }
           }
         }
       },
-      "PostExampleFormatMultiple200ResponseTimesYear": {
+      "PostExampleFormatMultiplePartYear": {
         "type": "object",
         "properties": {
           "as_string": {
@@ -786,7 +788,7 @@
           }
         }
       },
-      "PostExampleFormatMultiple200ResponseTimesAsArrayOfObjects": {
+      "PostExampleFormatMultiplePartAsArrayOfObjects": {
         "type": "object",
         "properties": {
           "as_integer": {
@@ -935,11 +937,11 @@
             "$ref": "#/components/schemas/Day"
           },
           "year": {
-            "$ref": "#/components/schemas/GetTestObject200ResponseTimeYear"
+            "$ref": "#/components/schemas/GetTestObjectPartYear"
           }
         }
       },
-      "GetTestObject200ResponseTimeYear": {
+      "GetTestObjectPartYear": {
         "type": "object",
         "properties": {
           "as_string": {
@@ -947,13 +949,30 @@
           }
         }
       },
-      "InvalidTestResponse": {
+      "SomethingVeryLongProblemBoomResponse": {
         "type": "object",
         "properties": {
           "code": {
             "type": "string",
             "enum": [
               "invalid_test"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "object"
+          }
+        }
+      },
+      "SoManyProblemsSoLittleTimeResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "so_many_problems"
             ]
           },
           "description": {
@@ -981,13 +1000,56 @@
           }
         }
       },
-      "OneOfInvalidTestAnotherInvalidTest400Response": {
+      "SomethingWrongResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "something_wrong"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "object"
+          }
+        }
+      },
+      "ReallyWrongResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "really_wrong"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "object"
+          }
+        }
+      },
+      "OneOfAnotherInvalidTestSomethingVeryLongProblemBoomSomethingWrong400Error": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/InvalidTestResponse"
+            "$ref": "#/components/schemas/SomethingVeryLongProblemBoomResponse"
+          },
+          {
+            "$ref": "#/components/schemas/SoManyProblemsSoLittleTimeResponse"
           },
           {
             "$ref": "#/components/schemas/AnotherInvalidTestResponse"
+          },
+          {
+            "$ref": "#/components/schemas/SomethingWrongResponse"
+          },
+          {
+            "$ref": "#/components/schemas/ReallyWrongResponse"
           }
         ]
       },
@@ -1014,11 +1076,11 @@
             "$ref": "#/components/schemas/Day"
           },
           "year": {
-            "$ref": "#/components/schemas/PostTestObject200ResponseTimeYear"
+            "$ref": "#/components/schemas/PostTestObjectPartYear"
           }
         }
       },
-      "PostTestObject200ResponseTimeYear": {
+      "PostTestObjectPartYear": {
         "type": "object",
         "properties": {
           "as_string": {
@@ -1107,12 +1169,12 @@
           }
         }
       },
-      "InvalidTestAnotherInvalidTest400Response": {
+      "AnotherInvalidTestSomethingVeryLongProblemBoomSomethingWrong400Error": {
         "description": "400 error response",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/OneOfInvalidTestAnotherInvalidTest400Response"
+              "$ref": "#/components/schemas/OneOfAnotherInvalidTestSomethingVeryLongProblemBoomSomethingWrong400Error"
             }
           }
         }


### PR DESCRIPTION
If we use a generator to produce a Ruby client, and then try to build that gem, it's possible for the RubyGems build process to fail with: `ERROR: While executing gem ... (Gem::Package::TooLongFileName)` This can happen if the $ref ids we are using are too long.

This PR makes 3 changes which are applied during the generation of ids only if they too long:
- error responses that can be "one of" many, will now no longer use all of the error names to generate the id
- nested partial responses will no longer use all of the parent field names in the id generation
- endpoint ids will resort to using the initials of the full path, when the id has a clash and the path is too long (this will be super rare).

this is a breaking change, but we're on 0.1.1 and not actually using any generated clients yet. So I'm not marking it as such.

closes: #46