### PR TITLE
feat: ensure apia objects can be declared as nullable

### DIFF
--- a/examples/core_api/objects/time.rb
+++ b/examples/core_api/objects/time.rb
@@ -22,7 +22,7 @@ module CoreAPI
         backend { |t| t.to_s }
       end
 
-      field :year, type: Objects::Year do
+      field :year, type: Objects::Year, null: true do
         backend { |t| t.year }
       end
 
@@ -46,7 +46,7 @@ module CoreAPI
         backend { |t| Base64.encode64(t.to_s) }
       end
 
-      field :as_date, type: :date do
+      field :as_date, type: :date, null: true do
         backend { |t| t.strftime("%Y-%m-%d") }
       end
 

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -788,12 +788,21 @@
             "type": "integer"
           },
           "year": {
-            "$ref": "#/components/schemas/PostExampleFormatMultiplePartYear"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PostExampleFormatMultiplePartYear"
+              }
+            ],
+            "nullable": true
           },
           "as_array_of_objects": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PostExampleFormatMultiplePartAsArrayOfObjects"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PostExampleFormatMultiplePartAsArrayOfObjects"
+                }
+              ]
             }
           }
         }
@@ -827,7 +836,12 @@
             "type": "string"
           },
           "year": {
-            "$ref": "#/components/schemas/Year"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Year"
+              }
+            ],
+            "nullable": true
           },
           "month": {
             "$ref": "#/components/schemas/MonthPolymorph"
@@ -841,7 +855,11 @@
           "as_array_of_objects": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Year"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Year"
+                }
+              ]
             }
           },
           "as_decimal": {
@@ -853,7 +871,8 @@
           },
           "as_date": {
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "nullable": true
           }
         }
       },
@@ -961,7 +980,12 @@
             "$ref": "#/components/schemas/Day"
           },
           "year": {
-            "$ref": "#/components/schemas/GetTestObjectPartYear"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GetTestObjectPartYear"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -1121,7 +1145,12 @@
             "$ref": "#/components/schemas/Day"
           },
           "year": {
-            "$ref": "#/components/schemas/PostTestObjectPartYear"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PostTestObjectPartYear"
+              }
+            ],
+            "nullable": true
           }
         }
       },


### PR DESCRIPTION
In Apia we can declare nullable fields like this:

```
class DiskTemplate < Apia::Object
  field :description, :string, null: true
  field :latest_version, Objects::DiskTemplateVersion, null: true
end
```

These are now declared as nullable in the spec.

closes: https://github.com/krystal/apia-openapi/issues/55