### PR TITLE
fix: handle nullable, remove duplication

### DIFF
--- a/examples/core_api/argument_sets/object_lookup.rb
+++ b/examples/core_api/argument_sets/object_lookup.rb
@@ -18,6 +18,13 @@ module CoreAPI
         http_status 404
       end
 
+      # this is intentionally a duplicate potential_error (it's also defined on the endpoint)
+      # to test that we deduplicate them
+      potential_error "SomethingWrong" do
+        code :something_wrong
+        http_status 400
+      end
+
       resolver do |set, _request, _scope|
         objects = [{ id: "123", permalink: "perma-123" }]
         object = objects.find { |o| o[:id] == set[:id] || o[:permalink] == set[:permalink] }

--- a/examples/core_api/base.rb
+++ b/examples/core_api/base.rb
@@ -3,6 +3,7 @@
 require "core_api/authenticators/main_authenticator"
 require "core_api/controllers/time_controller"
 require "core_api/endpoints/test_endpoint"
+require "core_api/endpoints/legacy_endpoint"
 
 module CoreAPI
   class Base < Apia::API
@@ -39,6 +40,13 @@ module CoreAPI
           get "time/formatting/incredibly/super/duper/long/format", endpoint: :format
           post "time/formatting/format", endpoint: :format
         end
+      end
+
+      # This endpoint should not be included in the OpenAPI spec
+      group :legacy do
+        no_schema
+
+        get "legacy", endpoint: Endpoints::LegacyEndpoint
       end
     end
 

--- a/examples/core_api/endpoints/legacy_endpoint.rb
+++ b/examples/core_api/endpoints/legacy_endpoint.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CoreAPI
+  module Endpoints
+    class LegacyEndpoint < Apia::Endpoint
+
+      description "We don't use this any more"
+
+      field :some_legacy_field, type: :string
+
+      def call
+        response.add_field :some_legacy_field, "hello!"
+      end
+
+    end
+  end
+end

--- a/examples/core_api/endpoints/test_endpoint.rb
+++ b/examples/core_api/endpoints/test_endpoint.rb
@@ -13,7 +13,9 @@ module CoreAPI
         description "Any string will do, it's not validated"
       end
 
-      field :time, type: Objects::Time, include: "unix,day_of_week,year[as_string]", null: true do
+      field :time,
+            type: Objects::Time,
+            include: "unix,day_of_week,year[*,-as_integer,-as_array_of_strings,-as_array_of_enums]", null: true do
         condition do |o|
           o[:time].year.to_s == "2023"
         end

--- a/examples/core_api/endpoints/time_now_endpoint.rb
+++ b/examples/core_api/endpoints/time_now_endpoint.rb
@@ -17,7 +17,9 @@ module CoreAPI
       end
       argument :filters, [:string]
 
-      field :time, type: Objects::Time do
+      # specifying `include: true` is not the correct way to use the option, but it's here to
+      # test that it doesn't break anything.
+      field :time, type: Objects::Time, include: true do
         description "A Time object"
       end
       field :time_zones, type: [Objects::TimeZone]

--- a/examples/core_api/endpoints/time_now_endpoint.rb
+++ b/examples/core_api/endpoints/time_now_endpoint.rb
@@ -27,9 +27,7 @@ module CoreAPI
       field :my_polymorph, type: Objects::MonthPolymorph do
         description "A polymorphic field!"
       end
-      field :my_partial_polymorph, type: Objects::MonthPolymorph, include: "number", null: true do
-        description "Partial polymorph"
-      end
+      field :my_partial_polymorph, type: Objects::MonthPolymorph, include: "number", null: true
 
       scope "time"
 

--- a/examples/core_api/objects/time.rb
+++ b/examples/core_api/objects/time.rb
@@ -14,7 +14,7 @@ module CoreAPI
         backend { |t| t }
       end
 
-      field :day_of_week, type: Objects::Day do
+      field :day_of_week, type: Objects::Day, null: true do
         backend { |t| t.strftime("%A") }
       end
 

--- a/lib/apia/open_api/helpers.rb
+++ b/lib/apia/open_api/helpers.rb
@@ -70,6 +70,8 @@ module Apia
         end
       end
 
+      # Converts the definition id to a short version:
+      # e.g. CoreAPI/Objects/TimeZone => TimeZone
       def generate_id_from_definition(definition)
         definition.id.split("/").last
       end

--- a/lib/apia/open_api/objects/response.rb
+++ b/lib/apia/open_api/objects/response.rb
@@ -157,8 +157,10 @@ module Apia
           }.compact
         end
 
+        # We used to check if field.include was nil, but explicitly checking for a string is more robust.
+        # As some apia definitions declare `include: true`, which is not the correct way to use the option.
         def field_includes_all_properties?(field)
-          field.include.nil?
+          !field.include.is_a?(String)
         end
 
         def generate_field_id(field_name)

--- a/lib/apia/open_api/objects/schema.rb
+++ b/lib/apia/open_api/objects/schema.rb
@@ -40,7 +40,7 @@ module Apia
           @definition = definition
           @schema = schema
           @id = id
-          @endpoint = endpoint # endpoint gets specified when we are dealing with a partial response
+          @endpoint = endpoint # endpoint gets specified when we are dealing with a partial response (see below)
           @path = path
           @children = []
         end
@@ -90,15 +90,34 @@ module Apia
 
           return if @children.empty?
 
-          all_properties_included = error_definition? || enum_definition? || @endpoint.nil?
           @children.each do |child|
             next unless @endpoint.nil? || (!enum_definition? && @endpoint.include_field?(@path + [child]))
 
+            all_properties_included = all_properties_included_for_child?(child)
             if child.respond_to?(:array?) && child.array?
               generate_schema_for_child_array(@schema, child, all_properties_included)
             else
               generate_schema_for_child(@schema, child, all_properties_included)
             end
+          end
+        end
+
+        # We need to check if all properties are included, because if they aren't we cannot use
+        # an existing schema $ref. We need to generate a new schema only for the endpoint.
+        # A field is considered 'partial' when declared in Apia with the `include` option, e.g.:
+        # ```
+        #   field :zones,
+        #     type: [Objects::Zone],
+        #     include: 'id,name,permalink,data_center[reference]'
+        # ```
+        # the above example means we only want to include the id, name and permalink fields for the zone
+        # and data_center is a nested object in zone, which should only include reference.
+        # so the parent zone is a partial object and the child data_center is also a partial object.
+        def all_properties_included_for_child?(child)
+          return true if error_definition? || enum_definition? || @endpoint.nil? || !child.type.object?
+
+          child.type.klass.definition.fields.values.all? do |child_field|
+            @endpoint.include_field?(@path + [child, child_field])
           end
         end
 

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -28,6 +28,9 @@ module Apia
           },
           security: []
         }
+
+        # path_ids is used to keep track of all the IDs of all the paths we've generated, to avoid duplicates
+        # refer to the Path object for more info
         @path_ids = []
         build_spec
       end
@@ -60,7 +63,9 @@ module Apia
 
       def add_paths
         @api.definition.route_set.routes.each do |route|
-          next unless route.endpoint.definition.schema? # not all routes should be documented
+          # not all routes should be documented
+          next unless route.group.nil? || route.group.schema?
+          next unless route.endpoint.definition.schema?
 
           Objects::Path.new(
             spec: @spec,

--- a/spec/apia/open_api/specification_spec.rb
+++ b/spec/apia/open_api/specification_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Apia::OpenApi::Specification do
 
       spec = described_class.new(example_api, base_url, "Core")
 
+      # uncomment the following line for debugging :)
+      # puts spec.json
       expected_spec = File.read(fixture_path).strip
 
       expect(spec.json).to eq(expected_spec)
@@ -26,6 +28,7 @@ RSpec.describe Apia::OpenApi::Specification do
     it "produces a valid spec" do
       spec = Openapi3Parser.load_file(fixture_path)
 
+      expect(spec.errors).to be_empty
       expect(spec.valid?).to be true
     end
   end

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -281,7 +281,6 @@
                           "$ref": "#/components/schemas/GetTimeNow200ResponseMyPartialPolymorph"
                         }
                       ],
-                      "description": "Partial polymorph",
                       "nullable": true
                     }
                   },
@@ -383,7 +382,6 @@
                           "$ref": "#/components/schemas/PostTimeNow200ResponseMyPartialPolymorph"
                         }
                       ],
-                      "description": "Partial polymorph",
                       "nullable": true
                     }
                   },
@@ -798,11 +796,7 @@
           "as_array_of_objects": {
             "type": "array",
             "items": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PostExampleFormatMultiplePartAsArrayOfObjects"
-                }
-              ]
+              "$ref": "#/components/schemas/PostExampleFormatMultiplePartAsArrayOfObjects"
             }
           }
         }
@@ -830,7 +824,12 @@
             "type": "integer"
           },
           "day_of_week": {
-            "$ref": "#/components/schemas/Day"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Day"
+              }
+            ],
+            "nullable": true
           },
           "full": {
             "type": "string"
@@ -855,11 +854,7 @@
           "as_array_of_objects": {
             "type": "array",
             "items": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Year"
-                }
-              ]
+              "$ref": "#/components/schemas/Year"
             }
           },
           "as_decimal": {
@@ -977,7 +972,12 @@
             "type": "integer"
           },
           "day_of_week": {
-            "$ref": "#/components/schemas/Day"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Day"
+              }
+            ],
+            "nullable": true
           },
           "year": {
             "allOf": [
@@ -994,6 +994,26 @@
         "properties": {
           "as_string": {
             "type": "string"
+          }
+        }
+      },
+      "SomethingWrongEnum": {
+        "type": "string",
+        "enum": [
+          "something_wrong"
+        ]
+      },
+      "SomethingWrongSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "$ref": "#/components/schemas/SomethingWrongEnum"
+          },
+          "description": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "object"
           }
         }
       },
@@ -1057,26 +1077,6 @@
           }
         }
       },
-      "SomethingWrongEnum": {
-        "type": "string",
-        "enum": [
-          "something_wrong"
-        ]
-      },
-      "SomethingWrongSchema": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "$ref": "#/components/schemas/SomethingWrongEnum"
-          },
-          "description": {
-            "type": "string"
-          },
-          "detail": {
-            "type": "object"
-          }
-        }
-      },
       "ReallyWrongEnum": {
         "type": "string",
         "enum": [
@@ -1100,6 +1100,9 @@
       "OneOfAnotherInvalidTestSomethingVeryLongProblemBoomSomethingWrong400Res": {
         "oneOf": [
           {
+            "$ref": "#/components/schemas/SomethingWrongSchema"
+          },
+          {
             "$ref": "#/components/schemas/SomethingVeryLongProblemBoomSchema"
           },
           {
@@ -1107,9 +1110,6 @@
           },
           {
             "$ref": "#/components/schemas/AnotherInvalidTestSchema"
-          },
-          {
-            "$ref": "#/components/schemas/SomethingWrongSchema"
           },
           {
             "$ref": "#/components/schemas/ReallyWrongSchema"
@@ -1142,7 +1142,12 @@
             "type": "integer"
           },
           "day_of_week": {
-            "$ref": "#/components/schemas/Day"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Day"
+              }
+            ],
+            "nullable": true
           },
           "year": {
             "allOf": [


### PR DESCRIPTION
Follow on from https://github.com/krystal/apia-openapi/pull/56

There were some places we didn't correctly set nullable for refs (sibling attrs are not allowed for refs).

We can set sibling attrs on refs, if we wrap them in `allOf`. This PR moves that fix into the central helper that generates most refs and we can enable it by specifying `sibling_props: true`.

It also fixes an issue where an apia endpoint declares the same error response (error code and http status) more than once. this can happen if say an ArgumentLookup declares an error response and then the endpoint itself does too.

the schema will no longer include endpoints in groups marked with `no_schema`.
Katapult has some of these for legacy endpoints. And these were also problematic as they used the same names
for a lot of api objects which were causing clashes.

the generator can also now handle when `include: true` (instead of a string). this is not the correct way to use the option, but Katapult uses it by accident presumably.

partial objects are now only generated when absolutely necessary. previously all child objects of a parent partial object were considered partial and this generated a unique entry in the schema. now we only generate partial child objects when absolutely necessary.

closes: #55