### PR TITLE
chore(security): pin unpinned GitHub actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,23 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }} # e.g. v1.0.0
       version: ${{ steps.release-please.outputs.version }} # e.g. 1.0.0
     steps:
-      - uses: krystal/release-please-manifest-action@v1
+      - uses: krystal/release-please-manifest-action@9e83450383c02fad51005c8248d04353da5be3ee # v3.0.0
         id: release-please
+        with:
+          target-branch-pattern: '^(main|master|release-[0-9]+(\.[0-9]+)?\.x)$'
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
         with:
           ruby-version: 3.2
       - name: Install dependencies
@@ -36,8 +39,8 @@ jobs:
           - 3.1
           - 3.2
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Install dependencies
@@ -51,10 +54,10 @@ jobs:
     needs: [release-please, test, lint]
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
         with:
           ruby-version: 3.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,11 @@ gemspec
 gem "apia", "~> 3.7"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
-gem "rubocop", "~> 1.21"
+gem "rubocop", "1.60.1"
 
 group :test do
-  gem "openapi3_parser"
+  gem "json", "2.7.1"
+  gem "openapi3_parser", "0.9.2"
   gem "pry"
   gem "simplecov", require: false
 end


### PR DESCRIPTION
- We don't want unpinned actions being used since those could become compromised.
- Also bumps actions to the latest versions